### PR TITLE
base: SystemUI: Fix circle battery QS tinting

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/battery/BatteryMeterView.java
+++ b/packages/SystemUI/src/com/android/systemui/battery/BatteryMeterView.java
@@ -73,16 +73,16 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
     public static final int MODE_OFF = 2;
     public static final int MODE_ESTIMATE = 3;
 
-    private static final int BATTERY_STYLE_PORTRAIT = 0;
-    private static final int BATTERY_STYLE_CIRCLE = 1;
-    private static final int BATTERY_STYLE_DOTTED_CIRCLE = 2;
-    private static final int BATTERY_STYLE_FULL_CIRCLE = 3;
-    private static final int BATTERY_STYLE_TEXT = 4; /*hidden icon*/
-    private static final int BATTERY_STYLE_HIDDEN = 5;
-    private static final int BATTERY_STYLE_BIG_CIRCLE = 6;
-    private static final int BATTERY_STYLE_BIG_DOTTED_CIRCLE = 7;
-    private static final int BATTERY_STYLE_RLANDSCAPE = 8;
-    private static final int BATTERY_STYLE_LANDSCAPE = 9;
+    public static final int BATTERY_STYLE_PORTRAIT = 0;
+    public static final int BATTERY_STYLE_CIRCLE = 1;
+    public static final int BATTERY_STYLE_DOTTED_CIRCLE = 2;
+    public static final int BATTERY_STYLE_FULL_CIRCLE = 3;
+    public static final int BATTERY_STYLE_TEXT = 4; /*hidden icon*/
+    public static final int BATTERY_STYLE_HIDDEN = 5;
+    public static final int BATTERY_STYLE_BIG_CIRCLE = 6;
+    public static final int BATTERY_STYLE_BIG_DOTTED_CIRCLE = 7;
+    public static final int BATTERY_STYLE_RLANDSCAPE = 8;
+    public static final int BATTERY_STYLE_LANDSCAPE = 9;
 
     private static final int BATTERY_PERCENT_HIDDEN = 0;
     private static final int BATTERY_PERCENT_SHOW_INSIDE = 1;
@@ -554,6 +554,10 @@ public class BatteryMeterView extends LinearLayout implements DarkReceiver {
         if (mUnknownStateDrawable != null) {
             mUnknownStateDrawable.setTint(singleToneColor);
         }
+    }
+
+    public int getBatteryStyle() {
+        return mBatteryStyle;
     }
 
     public void dump(FileDescriptor fd, PrintWriter pw, String[] args) {

--- a/packages/SystemUI/src/com/android/systemui/qs/QuickStatusBarHeader.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QuickStatusBarHeader.java
@@ -16,6 +16,11 @@ package com.android.systemui.qs;
 
 import static android.app.StatusBarManager.DISABLE2_QUICK_SETTINGS;
 import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
+import static com.android.systemui.battery.BatteryMeterView.BATTERY_STYLE_CIRCLE;
+import static com.android.systemui.battery.BatteryMeterView.BATTERY_STYLE_DOTTED_CIRCLE;
+import static com.android.systemui.battery.BatteryMeterView.BATTERY_STYLE_FULL_CIRCLE;
+import static com.android.systemui.battery.BatteryMeterView.BATTERY_STYLE_BIG_CIRCLE;
+import static com.android.systemui.battery.BatteryMeterView.BATTERY_STYLE_BIG_DOTTED_CIRCLE;
 
 import android.content.Context;
 import android.content.Intent;
@@ -326,6 +331,15 @@ public class QuickStatusBarHeader extends FrameLayout implements
             mClockView.setTextColor(textColor);
             if (mTintedIconManager != null) {
                 mTintedIconManager.setTint(textColor);
+            }
+            final int batteryStyle = mBatteryRemainingIcon.getBatteryStyle();
+            if (batteryStyle == BATTERY_STYLE_CIRCLE
+                    || batteryStyle == BATTERY_STYLE_DOTTED_CIRCLE
+                    || batteryStyle == BATTERY_STYLE_FULL_CIRCLE
+                    || batteryStyle == BATTERY_STYLE_BIG_CIRCLE
+                    || batteryStyle == BATTERY_STYLE_BIG_DOTTED_CIRCLE) {
+                textColorSecondary = Utils.getColorAttrDefaultColor(mContext,
+                        android.R.attr.textColorHint);
             }
             mBatteryRemainingIcon.updateColors(mTextColorPrimary, textColorSecondary,
                     mTextColorPrimary);


### PR DESCRIPTION
Battery background arc was tinted too close to differ
Replace textColorSecodary with textColorHint

[spezi77] Extended for dotted and full circle.
[amanrajOO7] Extended for Big Circle & Big Dotted Circle.

Signed-off-by: Aman Singh <amankumarsingh1412@gmail.com>